### PR TITLE
Add minimal CToS OS skeleton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+all: kernel/kernel.bin bootloader/bios/boot.bin
+
+kernel/kernel.bin:
+	$(MAKE) -C kernel kernel.bin
+
+bootloader/bios/boot.bin:
+	$(MAKE) -C bootloader/bios boot.bin
+
+clean:
+	$(MAKE) -C kernel clean
+	$(MAKE) -C bootloader/bios clean
+	$(MAKE) -C bootloader/uefi clean
+
+run: all
+	cat bootloader/bios/boot.bin kernel/kernel.bin > ctos.img
+	qemu-system-x86_64 -drive format=raw,file=ctos.img -m 64M -nographic

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # CToS
+
+CToS e um projeto de sistema operacional simples para PCs x86 com suporte a boot via BIOS e UEFI. Este repositorio contem um esqueleto basico com bootloaders e um kernel inicial escrito em C.
+
+## Estrutura
+
+- `bootloader/bios`  - Bootloader MBR para BIOS
+- `bootloader/uefi`  - Bootloader para UEFI (GPT)
+- `kernel`           - Kernel inicial
+- `iso`              - Diretorio para imagens
+
+## Compilacao rapida
+
+Para compilar o bootloader BIOS e o kernel e executar no QEMU:
+
+```
+make run
+```
+
+Para compilar o bootloader UEFI:
+
+```
+make -C bootloader/uefi
+```
+
+## Dependencias sugeridas
+
+- `nasm`
+- `gcc` com suporte a 32 bits (`gcc-multilib`)
+- `ld` e `objcopy` (binutils)
+- `gnu-efi` para compilar o loader UEFI
+- `qemu-system-x86_64` para testes
+

--- a/bootloader/bios/Makefile
+++ b/bootloader/bios/Makefile
@@ -1,0 +1,11 @@
+all: boot.bin
+
+boot.bin: boot.asm
+	nasm -f bin boot.asm -o boot.bin
+
+clean:
+	rm -f boot.bin ctos.img
+
+run: all ../../kernel/kernel.bin
+	cat boot.bin ../../kernel/kernel.bin > ctos.img
+	qemu-system-x86_64 -drive format=raw,file=ctos.img -m 64M

--- a/bootloader/bios/README.md
+++ b/bootloader/bios/README.md
@@ -1,0 +1,17 @@
+# BIOS Bootloader (MBR)
+
+Esta pasta contem o bootloader para BIOS (modo MBR). O arquivo `boot.asm` eh assemblado com NASM e gera o setor de boot. Ele carrega o kernel em modo protegido a partir dos setores seguintes do disco.
+
+### Como compilar
+
+```
+make
+```
+
+### Como testar
+
+O comando a seguir cria uma imagem de disquete `ctos.img` com o bootloader e o kernel e executa no QEMU:
+
+```
+make run
+```

--- a/bootloader/bios/boot.asm
+++ b/bootloader/bios/boot.asm
@@ -1,0 +1,88 @@
+[BITS 16]
+ORG 0x7c00
+
+start:
+    mov [BOOT_DRIVE], dl       ; Save boot drive
+
+    cli
+    xor ax, ax
+    mov ds, ax
+    mov es, ax
+    mov ss, ax
+    mov sp, 0x7c00
+    sti
+
+    ; Print loading message
+    mov si, msg
+.print:
+    lodsb
+    or al, al
+    jz .load
+    mov ah, 0x0e
+    mov bx, 0x0007
+    int 0x10
+    jmp .print
+
+.load:
+    ; Load kernel (16 sectors) to 0x100000
+    mov ax, 0x1000        ; segment 0x1000 -> 1MB
+    mov es, ax
+    xor bx, bx            ; offset 0
+    mov ah, 0x02          ; BIOS read sectors
+    mov al, 16            ; number of sectors
+    mov ch, 0
+    mov cl, 2            ; start at LBA 1 (sector 2 in CHS)
+    mov dh, 0
+    mov dl, [BOOT_DRIVE]
+    int 0x13
+    jc disk_error
+
+    ; Enable A20 (quick method)
+    in al, 0x92
+    or al, 2
+    out 0x92, al
+
+    ; Set up GDT
+    lgdt [gdt_descriptor]
+
+    ; Enter protected mode
+    mov eax, cr0
+    or eax, 1
+    mov cr0, eax
+    jmp CODE_SEL:protected_start
+
+disk_error:
+    hlt
+    jmp disk_error
+
+msg db 'Loading CToS...',0
+BOOT_DRIVE db 0
+
+; GDT
+ALIGN 4
+gdt_start:
+    dq 0x0000000000000000
+    dq 0x00cf9a000000ffff      ; code segment
+    dq 0x00cf92000000ffff      ; data segment
+gdt_end:
+
+gdt_descriptor:
+    dw gdt_end - gdt_start - 1
+    dd gdt_start
+
+CODE_SEL equ 0x08
+DATA_SEL equ 0x10
+
+[BITS 32]
+protected_start:
+    mov ax, DATA_SEL
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    mov ss, ax
+    mov esp, 0x90000
+    jmp 0x100000
+
+TIMES 510 - ($-$$) db 0
+DW 0xaa55

--- a/bootloader/uefi/Makefile
+++ b/bootloader/uefi/Makefile
@@ -1,0 +1,14 @@
+CFLAGS=-fpic -fshort-wchar -mno-red-zone -Wall -I/usr/include/efi -I/usr/include/efi/x86_64 -DEFI_FUNCTION_WRAPPER
+LDFLAGS=-nostdlib -znocombreloc -T /usr/lib/x86_64-linux-gnu/gnuefi/elf_x86_64_efi.lds -shared -Bsymbolic -L/usr/lib -lefi -lgnuefi
+
+target: loader.efi
+
+loader.o: loader.c
+	gcc $(CFLAGS) -c loader.c -o loader.o
+
+loader.efi: loader.o
+	ld $(LDFLAGS) loader.o -o loader.efi
+	objcopy -j .text -j .sdata -j .data -j .dynamic -j .dynsym -j .rel -j .rela -j .reloc -j .eh_frame -j .bss -j .rodata -O binary loader.efi loader.bin
+
+clean:
+	rm -f loader.o loader.efi loader.bin

--- a/bootloader/uefi/README.md
+++ b/bootloader/uefi/README.md
@@ -1,0 +1,20 @@
+# Bootloader UEFI (GPT)
+
+Este diretorio contem um exemplo de bootloader UEFI simples. Ele eh compilado utilizando a biblioteca gnu-efi e carrega o kernel tambem em formato EFI.
+
+### Como compilar
+
+```
+make
+```
+
+O resultado `loader.efi` deve ser colocado em `EFI/BOOT/BOOTX64.EFI` na particao FAT do disco de boot.
+
+### Como testar
+
+Crie uma imagem GPT com uma particao FAT contendo `loader.efi` e o kernel. Um exemplo de execucao no QEMU:
+
+```
+qemu-system-x86_64 -bios OVMF.fd -drive format=raw,file=ctos_uefi.img
+```
+

--- a/bootloader/uefi/loader.c
+++ b/bootloader/uefi/loader.c
@@ -1,0 +1,19 @@
+#include <efi.h>
+#include <efilib.h>
+
+EFI_STATUS
+EFIAPI
+efi_main (EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable) {
+    InitializeLib(ImageHandle, SystemTable);
+    Print(L"Iniciando CToS...\n");
+    // Carrega e executa o kernel (simplificado - kernel como EFI)
+    EFI_STATUS status;
+    EFI_HANDLE kernelHandle;
+    status = uefi_call_wrapper(SystemTable->BootServices->LoadImage, 6, FALSE, ImageHandle, NULL, NULL, 0, &kernelHandle);
+    if (EFI_ERROR(status)) {
+        Print(L"Falha ao carregar kernel\n");
+        return status;
+    }
+    status = uefi_call_wrapper(SystemTable->BootServices->StartImage, 3, kernelHandle, NULL, NULL);
+    return status;
+}

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,0 +1,11 @@
+CFLAGS=-m32 -ffreestanding -O2 -Wall -Wextra
+
+kernel.o: kernel.c
+	gcc $(CFLAGS) -c kernel.c -o kernel.o
+
+kernel.bin: kernel.o link.ld
+	ld -m elf_i386 -T link.ld kernel.o -o kernel.elf
+	objcopy -O binary kernel.elf kernel.bin
+
+clean:
+	rm -f kernel.o kernel.elf kernel.bin

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -1,0 +1,58 @@
+#include <stddef.h>
+#include <stdint.h>
+
+static uint16_t* const VIDEO = (uint16_t*)0xb8000;
+static uint16_t cursor = 0;
+
+static void putchar(char c) {
+    VIDEO[cursor++] = (uint16_t)c | 0x0700;
+}
+
+static void print(const char* s) {
+    while (*s) putchar(*s++);
+}
+
+static inline unsigned char inb(unsigned short port) {
+    unsigned char ret;
+    __asm__ volatile("inb %1, %0" : "=a"(ret) : "dN"(port));
+    return ret;
+}
+
+static char getkey() {
+    unsigned char sc;
+    do {
+        sc = inb(0x60);
+    } while (sc & 0x80);
+
+    switch(sc) {
+        case 0x1c: return '\n';
+        case 0x23: return 'h';
+        case 0x12: return 'e';
+        case 0x26: return 'l';
+        case 0x19: return 'p';
+        case 0x39: return ' ';
+        default: return 0;
+    }
+}
+
+void kernel_main() {
+    print("Bem-vindo ao CToS!\nDigite 'help' para ajuda.\n> ");
+    char buf[6];
+    int pos = 0;
+    while (1) {
+        char c = getkey();
+        if (!c) continue;
+        if (c == '\n') {
+            buf[pos] = '\0';
+            if (pos > 0 && !__builtin_strcmp(buf, "help")) {
+                print("\nCToS kernel inicial. Comandos: help\n> ");
+            } else {
+                print("\nComando desconhecido\n> ");
+            }
+            pos = 0;
+        } else {
+            if (pos < 5) buf[pos++] = c;
+            putchar(c);
+        }
+    }
+}

--- a/kernel/link.ld
+++ b/kernel/link.ld
@@ -1,0 +1,8 @@
+ENTRY(kernel_main)
+SECTIONS
+{
+    . = 1M;
+    .text : { *(.text*) }
+    .data : { *(.data*) }
+    .bss  : { *(.bss*)  *(COMMON) }
+}


### PR DESCRIPTION
## Summary
- implement BIOS bootloader in assembly
- add simple UEFI loader
- create basic C kernel printing a welcome message and simple help command
- add makefiles for building BIOS version and UEFI loader
- add README with build instructions and dependencies

## Testing
- `make`
- `make run` *(fails: qemu requires nographic which was fixed; manual run shows boot message)*

------
https://chatgpt.com/codex/tasks/task_e_684a4660ead88329ba14283cddd24f4b