### PR TITLE
Fix BIOS boot jump

### DIFF
--- a/bootloader/bios/boot.asm
+++ b/bootloader/bios/boot.asm
@@ -82,7 +82,8 @@ protected_start:
     mov gs, ax
     mov ss, ax
     mov esp, 0x90000
-    jmp 0x100000
+    mov eax, 0x100000
+    jmp eax
 
 TIMES 510 - ($-$$) db 0
 DW 0xaa55


### PR DESCRIPTION
## Summary
- adjust BIOS bootloader to correctly jump to kernel

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_684a5691058c8329a2da5b6a77a9976f